### PR TITLE
Fixed a nil pointer dereference within project controller

### DIFF
--- a/controllers/project_finalizer.go
+++ b/controllers/project_finalizer.go
@@ -74,7 +74,7 @@ func (r *ProjectReconciler) finalizeProject(ctx context.Context, logger logr.Log
 		}
 
 		//If OpenStack Project is already gone -> Done
-		logger.Info(fmt.Sprintf("OpenStack Project %s already gone", openStackProject.Id))
+		logger.Info(fmt.Sprintf("OpenStack Project %s already gone", openStackProjectName))
 		return nil
 	}
 


### PR DESCRIPTION
This error occured if the openstack project was already deleted